### PR TITLE
Added NSHighResolutionCapable to lmms.plist.in

### DIFF
--- a/cmake/apple/lmms.plist.in
+++ b/cmake/apple/lmms.plist.in
@@ -143,5 +143,7 @@
                 </dict>
             </dict>
         </array>
+        <key>NSHighResolutionCapable</key>
+        <string>True</string>
   </dict>
 </plist>


### PR DESCRIPTION
This will enable lmms in OSX to stop opening in low resolution mode and instead take advantage of retina display. It makes the title bar and text look clearer, but icons and images are unaffected and will still remain blurry.

Before
![before](https://cloud.githubusercontent.com/assets/9703998/21797441/ea84a77a-d6c3-11e6-9efd-6059c6d573d9.png)

After
<img width="1392" alt="after" src="https://cloud.githubusercontent.com/assets/9703998/21797442/ea854770-d6c3-11e6-806b-ddad6aefc180.png">

